### PR TITLE
map_n deprecated - use pmap instead

### DIFF
--- a/send-email-with-r.R
+++ b/send-email-with-r.R
@@ -29,7 +29,7 @@ edat
 write_csv(edat, "composed-emails.csv")
 
 emails <- edat %>%
-  map_n(mime)
+  pmap(mime)
 
 ## optional: use if you've created your own client id
 use_secret_file("gmailr-tutorial.json")


### PR DESCRIPTION
map_n deprecated since purrr v0.20 - pmap() (parallel map) replaces map_n() (#132), and has typed-variants suffixed pmap_lgl(), pmap_int(), pmap_dbl(), pmap_chr(), and pmap_df()